### PR TITLE
Be sure to exit with error code 0

### DIFF
--- a/tests/test-230f47cf.sh
+++ b/tests/test-230f47cf.sh
@@ -3,4 +3,4 @@ if [ $? -eq 0 ]; then
     exit 125;
 fi
 
-echo exit | ${PROOT} -v 0 ${PROOT_RAW} -v 0
+echo exit 0 | ${PROOT} -v 0 ${PROOT_RAW} -v 0


### PR DESCRIPTION
 With exit call without error code we will return exit code
of last command which may be not zero.