### PR TITLE
Use ORIGINAL instead of CURRENT to detect ptraced load done

### DIFF
--- a/src/execve/execve.h
+++ b/src/execve/execve.h
@@ -55,9 +55,9 @@ typedef struct load_info {
 
 #define IS_NOTIFICATION_PTRACED_LOAD_DONE(tracee) (			\
 		(tracee)->as_ptracee.ptracer != NULL			\
-		&& peek_reg((tracee), CURRENT, SYSARG_1) == (word_t) 1	\
-		&& peek_reg((tracee), CURRENT, SYSARG_4) == (word_t) 2	\
-		&& peek_reg((tracee), CURRENT, SYSARG_5) == (word_t) 3	\
-		&& peek_reg((tracee), CURRENT, SYSARG_6) == (word_t) 4)
+		&& peek_reg((tracee), ORIGINAL, SYSARG_1) == (word_t) 1	\
+		&& peek_reg((tracee), ORIGINAL, SYSARG_4) == (word_t) 2	\
+		&& peek_reg((tracee), ORIGINAL, SYSARG_5) == (word_t) 3	\
+		&& peek_reg((tracee), ORIGINAL, SYSARG_6) == (word_t) 4)
 
 #endif /* EXECVE_H */


### PR DESCRIPTION
 This fix bug in ptrace emulation for architecture where syscall
return value corrupt register use for syscall input.